### PR TITLE
use `getOrThrow` instead of manual checks in whatsapp service

### DIFF
--- a/src/whatsapp/whatsapp.service.ts
+++ b/src/whatsapp/whatsapp.service.ts
@@ -34,20 +34,16 @@ export class WhatsappService {
     private readonly conversationsService: ConversationsService,
     private readonly webhooksService: WebhooksService
   ) {
-    this.accessToken = this.configService.get<string>("WHATSAPP_ACCESS_TOKEN");
-    this.phoneNumberId = this.configService.get<string>(
+    this.accessToken = this.configService.getOrThrow<string>("WHATSAPP_ACCESS_TOKEN");
+    this.phoneNumberId = this.configService.getOrThrow<string>(
       "WHATSAPP_PHONE_NUMBER_ID"
     );
-    const apiVersion = this.configService.get<string>(
+    const apiVersion = this.configService.getOrThrow<string>(
       "WHATSAPP_API_VERSION",
       "v18.0"
     );
 
     this.baseUrl = `https://graph.facebook.com/${apiVersion}/${this.phoneNumberId}`;
-
-    if (!this.accessToken || !this.phoneNumberId) {
-      throw new Error("WhatsApp configuration is missing");
-    }
 
     this.logger.log("WhatsApp service initialized");
   }


### PR DESCRIPTION
This PR refactors `WhatsappService` to use `getOrThrow()` instead of `get()`, ensuring that required environment variables (WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID, WHATSAPP_API_VERSION) are present at runtime. As a result, manual checks for `accessToken` and `phoneNumberId` are no longer needed.